### PR TITLE
furthest_date_requested caculation bug

### DIFF
--- a/forecast.py
+++ b/forecast.py
@@ -119,8 +119,7 @@ class Forecast(object):
 
         # Get the furthest date in the future we can get a forecast for
         max_forecast_date = dt.now().date() + timedelta(days=MAX_FORECAST_LEN)
-        furthest_date_requested = dt.combine(date_start,
-                                             timedelta(days=forecast_length))
+        furthest_date_requested = date_start + timedelta(days=forecast_length)
 
         # Check to see that the forecast dates requested are not too far into
         # the future


### PR DESCRIPTION
current error/exception:  combine() argument 2 must be datetime.time, not datetime.timedelta
change to
= date_start + timedeltea(length)