### PR TITLE
no config changes

### DIFF
--- a/forecast.py
+++ b/forecast.py
@@ -119,8 +119,7 @@ class Forecast(object):
 
         # Get the furthest date in the future we can get a forecast for
         max_forecast_date = dt.now().date() + timedelta(days=MAX_FORECAST_LEN)
-        furthest_date_requested = dt.combine(date_start,
-                                             timedelta(days=forecast_length))
+        furthest_date_requested = date_start + timedelta(days=forecast_length)
 
         # Check to see that the forecast dates requested are not too far into
         # the future

--- a/main.py
+++ b/main.py
@@ -58,7 +58,8 @@ def webhook():
         log.error('Unexpected action.')
 
     print('Action: ' + action)
-    print('Response: ' + res)
+    print('Response:')
+    print(res)
 
     return make_response(jsonify({'fulfillmentText': res}))
 
@@ -78,14 +79,17 @@ def weather(req):
     # validate request parameters, return an error if there are issues
     error, forecast_params = validate_params(parameters)
     if error:
-        return error
+        print(error, forecast_params)
+        return str(error)
 
     # create a forecast object which retrieves the forecast from a external API
     try:
         forecast = Forecast(forecast_params)
     # return an error if there is an error getting the forecast
     except (ValueError, IOError) as error:
-        return error
+        print('Forecast error')
+        print(error, forecast_params)
+        return str(error)
 
     # If the user requests a datetime period (a date/time range), get the
     # response


### PR DESCRIPTION
Fix the `dt.combine(date, timdelta)` line that throws an exception on Python 3.6.  `bytes` are still improperly interpolated into the unicode response `str`; this doesn't fix that.